### PR TITLE
typo

### DIFF
--- a/docs/attributes/text-editors.md
+++ b/docs/attributes/text-editors.md
@@ -19,7 +19,7 @@ meteor add orionjs:summernote
 or
 
 ```sh
-meteor add orionjs:froala-editor
+meteor add orionjs:froala
 ```
 
 ## Examples


### PR DESCRIPTION
In v1.0 the correct package name for froala is `orionjs:froala`