### PR TITLE
Add orion-file-collection reference

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -58,6 +58,8 @@ If you want to help translating Orion to your language follow the [instructions]
 
 **Filesystem:**
 
+- [vsivsi:orion-file-collection](https://atmospherejs.com/vsivsi/orion-file-collection) Lightweight MongoDB gridFS support
+
 - [lc3t35:orion-filesystem-local](https://github.com/lc3t35/orion-filesystem-local)
 
 - [brightbind:orion-gridfs](https://github.com/brightbind/orion-gridFS/)


### PR DESCRIPTION
Hi, I just finished an initial version of an Orion filesystem package supporting my file-collection package that uses MongoDB gridFS + resumable.js for file storage and uploading.  For more information see: 
https://atmospherejs.com/vsivsi/orion-file-collection

This PR adds a link and four word description for this package to the "Community add-on" section of the introduction.
